### PR TITLE
update se.avtalsbanken:weblib to 3.1.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
 		<dependency>
 			<groupId>se.avtalsbanken</groupId>
 			<artifactId>weblib</artifactId>
-			<version>3.1.11</version>
+			<version>3.1.12</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
[UpdateBot](https://github.com/jenkins-x/updatebot) pushed maven dependency: `se.avtalsbanken:weblib` to: `3.1.12`